### PR TITLE
Allow --set flag to parse a list of <key>=<value> assignments to embed on the helm values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Helm-generate also handles the namespace injection on the manifests, as `helm te
 
 There are two required keys on `values.yaml`: namespace and releaseName. Those are internally used by helm-generate to correctly render the desired charts.
 
+It is possible to inject `(key -> value)` pairs to the top level of the values map through the CLI, using the flag `--set my_key=my_value`. This flag is parsed as `[]string`, therefore it can be passed multiple times to inject multiple pairs. This flag overrides the values from `values.yaml`.
+
 ## .helm.yaml
 This is a special control file designed to change the behavior of helm-generate for a specific folder, this don't apply to any subfolders.
 The current keys available at .helm.yaml are:

--- a/cmd/helm-generate/helm-generate_test.go
+++ b/cmd/helm-generate/helm-generate_test.go
@@ -61,6 +61,7 @@ func TestInstallChartWithArgs(t *testing.T) {
 		mockCmd.Flags().String(flagHelmYamlFilename, ".helm.yaml", "")
 		mockCmd.Flags().StringP(flagHelmValuesFilename, "f", "values.yaml", "")
 		mockCmd.Flags().StringP(flagPostRenderBinary, "p", "", "")
+		mockCmd.Flags().StringArray(flagSetKeyValue, []string{"cluster=cluster-name"}, "")
 
 		b, testError := helmGenerate(mockCmd, []string{test.Sample.(string)})
 		cmdOutput, err := ioutil.ReadAll(&b)

--- a/cmd/helm-generate/main.go
+++ b/cmd/helm-generate/main.go
@@ -29,6 +29,7 @@ var (
 	flagPostRenderBinary    = "post-render-binary"
 	flagHelmYamlFilename    = "helm-yaml"
 	flagHelmValuesFilename  = "values-yaml"
+	flagSetKeyValue         = "set"
 )
 
 // initConfig reads in config file and ENV variables if set.
@@ -60,6 +61,7 @@ func init() {
 	rootCmd.Flags().String(flagHelmYamlFilename, ".helm.yaml", "File to look for helm chart configuration (Defaults to .helm.yaml)")
 	rootCmd.Flags().StringP(flagHelmValuesFilename, "f", "values.yaml", "Filename of the helm values file (Defaults to values.yaml)")
 	rootCmd.Flags().StringP(flagPostRenderBinary, "p", "", "A command to run after rendering the Helm templates")
+	rootCmd.Flags().StringArray(flagSetKeyValue, []string{}, "List of <key>=<value> strings representing a property and its value to be assigned on the top level of the chart values.")
 }
 
 func main() {

--- a/cmd/helm-generate/tests/cronjob-chart/templates/cronjob.yaml
+++ b/cmd/helm-generate/tests/cronjob-chart/templates/cronjob.yaml
@@ -1,6 +1,7 @@
 {{- $chart_name := .Chart.Name }}
 {{- $chart_version := .Chart.Version | replace "+" "_" }}
 {{- $release_name := .Release.Name }}
+{{- $cluster_name := .Values.cluster }}
 
 {{- range $job := .Values.jobs }}
 ---
@@ -37,6 +38,8 @@ spec:
             name: {{ $job.name }}
             {{- with $job.env }}
             env:
+            - name: CLUSTER
+              value: {{ $cluster_name }}
 {{ toYaml . | indent 12 }}
             {{- end }}
             {{- if $job.command }}

--- a/cmd/helm-generate/tests/expected/multiple-apps/output.yaml
+++ b/cmd/helm-generate/tests/expected/multiple-apps/output.yaml
@@ -189,6 +189,8 @@ spec:
             command:
             - /bin/sh
             env:
+            - name: CLUSTER
+              value: cluster-name
             - name: ECHO_VAR
               value: busybox
             image: busybox:latest

--- a/cmd/helm-generate/tests/expected/namespace-dedup/output.yaml
+++ b/cmd/helm-generate/tests/expected/namespace-dedup/output.yaml
@@ -180,6 +180,8 @@ spec:
             command:
             - /bin/sh
             env:
+            - name: CLUSTER
+              value: cluster-name
             - name: ECHO_VAR
               value: busybox
             image: busybox:latest

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/afero v1.3.2 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -31,11 +31,12 @@ type Configurator interface {
 
 // Configuration defines a struct for the .helm.yaml file
 type Configuration struct {
-	Chart            string `yaml:"chart"`
-	ChartVersion     string `yaml:"chartVersion"`
-	HelmYaml         string
-	ValuesYaml       string
-	PostRenderBinary string `yaml:"postRenderBinary"`
+	Chart               string `yaml:"chart"`
+	ChartVersion        string `yaml:"chartVersion"`
+	HelmYaml            string
+	ValuesYaml          string
+	PostRenderBinary    string `yaml:"postRenderBinary"`
+	KeyValueAssignments map[string]string
 }
 
 func addNamespaceMetadata(manifests []map[string]interface{}, namespace string) ([]map[string]interface{}, error) {


### PR DESCRIPTION
This PR adds a Cobra flag called `set`, which is parsed as string slice. Each string must be of the form `<key>=<value>`. If all strings are compliant, then they are all added to the top level scope of Helm's values file. #5 