### PR TITLE
Don't parse empty manifests

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -44,6 +44,10 @@ func addNamespaceMetadata(manifests []map[string]interface{}, namespace string) 
 		return nil, fmt.Errorf("Empty manifest list")
 	}
 	for _, manifest := range manifests {
+		// Some helm chart produce empty manfiests
+		if len(manifest) == 0 {
+			continue
+		}
 		_, err := util.NestedMapLookup(manifest, "metadata")
 		if err == nil {
 			manifest["metadata"].(map[interface{}]interface{})["namespace"] = namespace

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -329,6 +329,7 @@ func TestInstallChart(t *testing.T) {
 }
 
 func TestAddNamespaceMetadata(t *testing.T) {
+	emptyMap := map[string]interface{}{}
 	namespace := "test-namespace"
 	tests := []TestCase{
 		{
@@ -366,10 +367,11 @@ func TestAddNamespaceMetadata(t *testing.T) {
 		},
 		{
 			Name:   "empty manifest",
-			Sample: []map[string]interface{}{},
+			Sample: []map[string]interface{}{emptyMap},
+
 			Expected: ReturnWithError{
-				Value: nil,
-				Error: true,
+				Value: []map[string]interface{}{emptyMap},
+				Error: false,
 			},
 		},
 		{


### PR DESCRIPTION
Some helm charts output things like:
```
---
# Some random comments.
---
```

Which generates an empty manifest. helm-generate should avoid them
instead of throwing an error.